### PR TITLE
Config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,22 @@ poetry run streamlit run dashboard.py
 Before that, you'll need a `.env` file with these keys:
 
 ```
+OPENAI_API_BASE=https://api.openai.com/v1
+OPENAI_KEY=
+OAUTH_CLIENT_URI=
 OAUTH_CLIENT_ID=
 OAUTH_CLIENT_SECRET=
 ACCESS_TOKEN=
-OPENAI_KEY=
 ```
 
-* Oauth (first 3) — In your mastodon UI, create a new "app" and copy the information into these
-* OpenAI Key — create an account and paste the key here
-
+| Variable            | Value                                    |
+| ---                 | ---                                      |
+| OPENAI_API_BASE     | eg. https://api.openai.com/v1            |
+| OPENAI_KEY          | Create an account and paste the key here |
+| OAUTH_CLIENT_URI    | eg. https://hackyderm.io                 |
+| OAUTH_CLIENT_ID     | In your mastodon UI, create a new "app" and copy the information into these: |
+| OAUTH_CLIENT_SECRET |                                          |
+| ACCESS_TOKEN        |                                          |
 
 # Status
 It works on my box

--- a/fossil/core.py
+++ b/fossil/core.py
@@ -153,7 +153,8 @@ def download_timeline(since: datetime.datetime):
     earliest_date = None
     buffer: list[Toot] = []
     last_id = ""
-    curr_url = f"https://hachyderm.io/api/v1/timelines/home?limit=40"
+    oauth_uri = config.get_config()["OAUTH_CLIENT_URI"]
+    curr_url = f"{oauth_uri}/api/v1/timelines/home?limit=40"
     import json as JSON
     while not earliest_date or earliest_date > last_date:
         response = requests.get(curr_url, headers=config.headers())

--- a/fossil/core.py
+++ b/fossil/core.py
@@ -193,7 +193,7 @@ def download_timeline(since: datetime.datetime):
 
 def _create_embeddings(toots: list[Toot]):
     # Convert the list of toots to a single string
-    client = openai.OpenAI(api_key=config.get_config()["OPENAI_KEY"])
+    client = openai.OpenAI(api_key=config.get_config()["OPENAI_KEY"], base_url=config.get_config()["OPENAI_API_BASE"])
     toots = [t for t in toots if t.content]
 
     # Call the OpenAI Text Embedding API to create embeddings

--- a/fossil/science.py
+++ b/fossil/science.py
@@ -15,7 +15,7 @@ def assign_clusters(toots: list[core.Toot], n_clusters: int = 5):
     kmeans = KMeans(n_clusters=n_clusters)
     cluster_labels = kmeans.fit_predict(embeddings)
 
-    client = openai.OpenAI(api_key=config.get_config()["OPENAI_KEY"])
+    client = openai.OpenAI(api_key=config.get_config()["OPENAI_KEY"], base_url=config.get_config()["OPENAI_API_BASE"])
     for i_clusters in range(n_clusters):
         clustered_toots = [toot for toot, cluster_label in zip(toots, cluster_labels) if cluster_label == i_clusters]
         combined_text = "\n\n".join([toot.content for toot in clustered_toots])


### PR DESCRIPTION
Oh, sorry, you're splitting the `.env` file be hand; went right over my head!
Here are those configuration option commits again, rebased into `main`, with one more to correct the README example of an `.env` file that would not have parsed. I moved the comments into a table, but of course you're free to do whatever you like, I just think it's important these get through in case anyone else wants to give it a go :p