### PR TITLE
Redid Configuration Code, Edits for Using Local Models, and Minor Cleaning

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -17,7 +17,7 @@ def get_toots(_cache_key: int, timeline_since, n_clusters) -> list[core.Toot]:
     toots = core.Toot.get_toots_since(datetime.datetime.utcnow() - timeline_since)
     if len(toots) > 0:
         ui.all_toot_summary(toots)
-        science.assign_clusters(toots, n_clusters=n_clusters)
+        science.assign_clusters(st.session_state['id'], toots, n_clusters=n_clusters)
     return toots
 
 # Refresh button
@@ -27,7 +27,7 @@ if latest_date is None:
     if is_refreshing:
         with st.spinner("Downloading toots..."):
             core.create_database()
-            core.download_timeline(datetime.datetime.utcnow() - datetime.timedelta(days=1))
+            core.download_timeline(datetime.datetime.utcnow() - datetime.timedelta(days=1), st.session_state['id'])
             latest_date = core.Toot.get_latest_date()
         st.session_state.cache_key = random.randint(0, 10000)
 else:
@@ -35,7 +35,7 @@ else:
     if is_refreshing:
         with st.spinner("Downloading toots..."):
             core.create_database()
-            core.download_timeline(latest_date)
+            core.download_timeline(latest_date,  st.session_state['id'])
         st.session_state.cache_key = random.randint(0, 10000)
 
 # customize timeline segment to analyze

--- a/fossil_mastodon/algorithm/base.py
+++ b/fossil_mastodon/algorithm/base.py
@@ -6,9 +6,9 @@ import sqlite3
 import traceback
 import typing
 
-from fastapi import templating, Response, responses, Request
 import pkg_resources
 import pydantic
+from fastapi import Request, Response, responses, templating
 
 from fossil_mastodon import config, core, ui
 
@@ -51,12 +51,13 @@ class TrainContext(pydantic.BaseModel):
     """
     end_time: datetime.datetime
     timedelta: datetime.timedelta
+    session_id: str
 
     def get_toots(self) -> list[core.Toot]:
         return core.Toot.get_toots_since(self.end_time - self.timedelta)
 
     def sqlite_connection(self) -> sqlite3.Connection:
-        return sqlite3.connect(config.DATABASE_PATH)
+        return sqlite3.connect(config.ConfigHandler.DATABASE_PATH)
 
 
 class BaseAlgorithm(abc.ABC):

--- a/fossil_mastodon/app/templates/settings.html
+++ b/fossil_mastodon/app/templates/settings.html
@@ -19,7 +19,7 @@
             <div class="status-target" id="embedding_model_status"></div>
         </div>
 
-        <label for="embedding_model">Embedding model</label>
+        <label for="summarize_model">Summarizing model</label>
         <div class="row">
             <select name="summarize_model" id="summarize_model" hx-trigger="change" hx-target="#summarize_model_status" hx-post="/settings">
                 <option value="" {% if summarize_model == "" %}selected{% endif %}>None</option>

--- a/fossil_mastodon/config.py
+++ b/fossil_mastodon/config.py
@@ -1,47 +1,91 @@
 import atexit
 import functools
+import json
+import os
 import pathlib
 import shutil
+import sqlite3
 import tempfile
+from collections import defaultdict
+
 import llm
-
 import pydantic
+from dotenv import dotenv_values
 
 
-@functools.lru_cache()
-def get_config():
-    import os
-    import dotenv
-    dotenv.load_dotenv()
-    return os.environ
-
-
-def headers():
-    return {"Authorization": f"Bearer {ACCESS_TOKEN}"}
-
+def get_config_var(var_name: str, default):
+    return dotenv_values().get(var_name, os.environ.get(var_name, default))
 
 class Model(pydantic.BaseModel):
     name: str
     context_length: int
 
+class _ConfigValueNotFound():
+    pass
 
-ALL_MODELS: dict[str, Model] = {m.name: m for m in [
-    Model(name="gpt-3.5-turbo", context_length=4097),
-    Model(name="ada-002", context_length=8191),
-]}
+ConfigValueNotFound = _ConfigValueNotFound()
 
-DATABASE_PATH = get_config().get("DATABASE_PATH", "fossil.db")
+class _ConfigHandler():
+    # Default fallbacks for variables defined in either .env or environment
+    _config_var_defaults = {
+        "DATABASE_PATH": "fossil.db",
+        "OPENAI_KEY": "",
+        "OPENAI_API_BASE": "https://api.openai.com/v1",
+        "MASTO_BASE": "https://hachyderm.io",
+    }
+    
+    _model_lengths = defaultdict(
+        lambda: 10000, 
+        {"gpt-3.5-turbo": 4097, "ada-002": 8191}
+    )
+    
+    _model_cache = {}
+    
+    def __getattr__(self, item: str):
+        c_val = get_config_var(item, self._config_var_defaults.get(item, ConfigValueNotFound))
+        
+        if isinstance(c_val, _ConfigValueNotFound):
+            raise AttributeError(f"{item} is not defined in either the enviroment or .env file")
+        return c_val
+
+    def _get_from_session(self, session_id: str| None, item: str) -> str:
+        if not session_id:
+            return ""
+        with sqlite3.connect(self.DATABASE_PATH) as conn:
+            c = conn.cursor()
+            c.execute('SELECT settings FROM sessions WHERE id = ?', [session_id])
+            row = c.fetchone()
+            try:
+                return json.loads(row[0]).get(item, "")
+            except (json.decoder.JSONDecodeError, IndexError, TypeError):
+                return ""
+    
+    def EMBEDDING_MODEL(self, session_id: str|None = None) -> Model:
+        c_val = self._get_from_session(session_id, "embedding_model")
+        if not c_val:
+            c_val = get_config_var("EMBEDDING_MODEL", "ada-002")
+        
+        if c_val not in self._model_cache:
+            self._model_cache[c_val] = Model(name=c_val, context_length=self._model_lengths[c_val])
+        
+        return self._model_cache[c_val]
+    
+    def SUMMARIZE_MODEL(self, session_id: str|None = None) -> Model:
+        c_val = self._get_from_session(session_id, "summarize_model")
+        if not c_val:
+            c_val = get_config_var("SUMMARIZE_MODEL", "gpt-3.5-turbo")
+            
+        if c_val not in self._model_cache:
+            self._model_cache[c_val] = Model(name=c_val, context_length=self._model_lengths[c_val])
+        
+        return self._model_cache[c_val]
 
 
-# Required keys in either .env or environment variables
-ACCESS_TOKEN = get_config()["ACCESS_TOKEN"]
-OPENAI_KEY = get_config()["OPENAI_KEY"]
+ConfigHandler = _ConfigHandler()
 
-# Optional keys in either .env or environment variables
-OPENAI_API_BASE = get_config().get("OPENAI_API_BASE", "https://api.openai.com/v1")
-MASTO_BASE = get_config().get("MASTO_BASE", "https://hachyderm.io")
-EMBEDDING_MODEL = ALL_MODELS[get_config().get("EMBEDDING_MODEL", "ada-002")]
-SUMMARIZE_MODEL = ALL_MODELS[get_config().get("SUMMARIZE_MODEL", "gpt-3.5-turbo")]
+
+def headers():
+    return {"Authorization": f"Bearer {ConfigHandler.ACCESS_TOKEN}"}
 
 def get_installed_llms() -> set[str]:
     return {m.model.model_id for m in llm.get_models_with_aliases()}

--- a/fossil_mastodon/science.py
+++ b/fossil_mastodon/science.py
@@ -1,13 +1,13 @@
 import llm
 import numpy as np
 import openai
-from . import core, config
-from sklearn.cluster import KMeans
-import openai
 import tiktoken
+from sklearn.cluster import KMeans
+
+from . import config, core
 
 
-def assign_clusters(toots: list[core.Toot], n_clusters: int = 5):
+def assign_clusters(session_id: str, toots: list[core.Toot], n_clusters: int = 5):
     # meh, ignore toots without content. I think this might be just an image, not sure
     toots = [toot for toot in toots if toot.embedding is not None]
 
@@ -16,14 +16,14 @@ def assign_clusters(toots: list[core.Toot], n_clusters: int = 5):
     kmeans = KMeans(n_clusters=n_clusters)
     cluster_labels = kmeans.fit_predict(embeddings)
 
-    client = openai.OpenAI(api_key=config.OPENAI_KEY)
+    client = openai.OpenAI(api_key=config.ConfigHandler.OPENAI_KEY)
     for i_clusters in range(n_clusters):
         clustered_toots = [toot for toot, cluster_label in zip(toots, cluster_labels) if cluster_label == i_clusters]
         combined_text = "\n\n".join([toot.content for toot in clustered_toots])
 
         # Use GPT-3.5-turbo to summarize the combined text
         prompt = f"Create a single label that describes all of these related tweets, make it succinct but descriptive. The label should describe all {len(clustered_toots)} of these\n\n{combined_text}"
-        model = llm.get_model(config.SUMMARIZE_MODEL.name)
+        model = llm.get_model(config.ConfigHandler.SUMMARIZE_MODEL(session_id).name)
         summary = model.prompt(prompt).text()
 
         # Do something with the summary
@@ -31,9 +31,15 @@ def assign_clusters(toots: list[core.Toot], n_clusters: int = 5):
             if cluster_label == i_clusters:
                 toot.cluster = summary
 
+def get_encoding(session_id: str):
+    try:
+        return tiktoken.encoding_for_model(config.ConfigHandler.SUMMARIZE_MODEL(session_id).name)
+    except KeyError:
+        encoding_name = tiktoken.list_encoding_names()[-1]
+        return tiktoken.get_encoding(encoding_name)
 
-ENCODING = tiktoken.encoding_for_model(config.SUMMARIZE_MODEL.name)
-
-def reduce_size(text: str, model_limit: int = config.SUMMARIZE_MODEL.context_length, est_output_size: int = 500) -> str:
-    tokens = ENCODING.encode(text)
-    return ENCODING.decode(tokens[:model_limit - est_output_size])
+def reduce_size(session_id: str, text: str, model_limit: int = -1, est_output_size: int = 500) -> str:
+    if model_limit < 0:
+        config.ConfigHandler.SUMMARIZE_MODEL(session_id).context_length
+    tokens = get_encoding(session_id).encode(text)
+    return get_encoding(session_id).decode(tokens[:model_limit - est_output_size])

--- a/fossil_mastodon/ui.py
+++ b/fossil_mastodon/ui.py
@@ -5,7 +5,8 @@ import urllib.parse
 import pydantic
 import streamlit as st
 
-from . import core, config
+from . import config, core
+
 
 def get_time_frame() -> datetime.timedelta:
     time_frame = st.radio("Show last:", ["6 hours", "day", "week"], horizontal=True)
@@ -55,7 +56,7 @@ def timedelta(time_span: str) -> datetime.timedelta:
 class LinkStyle:
     def __init__(self, scheme: str | None = None):
         # ivory://acct/openURL?url=
-        # {config.MASTO_BASE}/deck/@{toot.author}/{toot.toot_id}
+        # {config.ConfigHandler.MASTO_BASE}/deck/@{toot.author}/{toot.toot_id}
         if scheme:
             self.scheme = st.radio("Link scheme:", ["Desktop", "Ivory", "Original"], index=1, horizontal=True)
         else:
@@ -63,7 +64,7 @@ class LinkStyle:
 
     def toot_url(self, toot: core.Toot) -> str:
         if self.scheme == "Desktop":
-            return f"{config.MASTO_BASE}/@{toot.author}/{toot.toot_id}"
+            return f"{config.ConfigHandler.MASTO_BASE}/@{toot.author}/{toot.toot_id}"
         elif self.scheme == "Ivory":
             encoded_url = urllib.parse.quote(toot.url)
             return f"ivory://acct/openURL?url={encoded_url}"
@@ -73,7 +74,7 @@ class LinkStyle:
 
     def profile_url(self, toot: core.Toot) -> str:
         if self.scheme == "Desktop":
-            return f"{config.MASTO_BASE}/@{toot.author}"
+            return f"{config.ConfigHandler.MASTO_BASE}/@{toot.author}"
         elif self.scheme == "Ivory":
             # return f"ivory://@{toot.author}/profile"
             return f"ivory://acct/openURL?url={toot.profile_url}"


### PR DESCRIPTION
As discussed in https://github.com/tkellogg/fossil/issues/15#issuecomment-1881460619 the configuration variables were not propagating into the code. I fixed this by creating a configuration manager object which performs a series of look ups when asked for a specific variable from the configuration state: first from the sqllite database, then from the `.env` file, and finally from the host environment. 

I also had to change the way the reduction step works to use the `session_id` and to account for models not found in `tiktoken`. Additionally, I sorted the imports using isort, changed "embedding model" to "summarizing model" in the settings page, and added a `tqdm` progress bar to the summarization step.